### PR TITLE
feat: different margin size for xl and lg

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -7,7 +7,7 @@
     <title>Vite App</title>
   </head>
   <body>
-    <div id="app" class="lg:mx-96 md:mx-44"></div>
+    <div id="app" class="xl:mx-96 lg:mx-64 md:mx-44"></div>
     <script type="module" src="/src/main.js"></script>
   </body>
 </html>


### PR DESCRIPTION
# Main Change
<img width="578" alt="image" src="https://user-images.githubusercontent.com/14107090/218579794-cd024573-886e-45b6-833c-67f0525bcb56.png">

- 화면이 lg 사이즈일 때 margin이 너무 큰 문제 해결
- margin을 더 작게 표시함(96 -> 64)